### PR TITLE
Mpitem

### DIFF
--- a/src/api/models/ListingItem.ts
+++ b/src/api/models/ListingItem.ts
@@ -4,6 +4,7 @@ import { ItemInformation } from './ItemInformation';
 import { PaymentInformation } from './PaymentInformation';
 import { MessagingInformation } from './MessagingInformation';
 import { ListingItemObject } from './ListingItemObject';
+import { ListingItemSearchParams } from '../requests/ListingItemSearchParams';
 
 
 export class ListingItem extends Bookshelf.Model<ListingItem> {
@@ -93,7 +94,7 @@ export class ListingItem extends Bookshelf.Model<ListingItem> {
         }
     }
 
-    public static async searchBy(options: any): Promise<Collection<ListingItem>> {
+    public static async searchBy(options: ListingItemSearchParams, withRelated: boolean = false): Promise<Collection<ListingItem>> {
 
         const listingCollection = ListingItem.forge<Collection<ListingItem>>()
             .query( qb => {
@@ -114,7 +115,7 @@ export class ListingItem extends Bookshelf.Model<ListingItem> {
 
             });
 
-        if (options.withRelated) {
+        if (withRelated) {
             return await listingCollection.fetchAll({
                 withRelated: [
                     'ItemInformation',

--- a/src/api/repositories/ListingItemRepository.ts
+++ b/src/api/repositories/ListingItemRepository.ts
@@ -27,13 +27,6 @@ export class ListingItemRepository {
         return await this.ListingItemModel.fetchByCategory(categoryId, withRelated);
     }
 
-    /**
-     * TODO: remove
-     */
-    public async searchByCategoryIdOrName(options: any): Promise<Bookshelf.Collection<ListingItem>> {
-        return this.ListingItemModel.searchByCategoryOrName(options[0], options[1], options[2]);
-    }
-
     public async findOne(id: number, withRelated: boolean = true): Promise<ListingItem> {
         return this.ListingItemModel.fetchById(id, withRelated);
     }
@@ -54,21 +47,8 @@ export class ListingItemRepository {
      * @returns {Promise<Bookshelf.Collection<ListingItem>>}
      */
     public async search(options: ListingItemSearchParams): Promise<Bookshelf.Collection<ListingItem>> {
-        const list = await this.ListingItemModel.forge<ListingItem>()
-            .query((qb: any) => {
-                qb.innerJoin('item_informations', 'item_informations.listing_item_id', 'listing_items.id');
-                qb.groupBy('listing_items.id');
-            })
+        return this.ListingItemModel.searchBy(options);
 
-            .orderBy('item_informations.title', options.order).query({
-                limit: options.pageLimit,
-                offset: (options.page - 1) * options.pageLimit
-
-            })
-
-            .fetchAll({withRelated: ['ItemInformation', 'ItemInformation.ItemCategory']});
-
-        return list as Bookshelf.Collection<ListingItem>;
     }
 
     public async create(data: any): Promise<ListingItem> {

--- a/src/api/repositories/ListingItemRepository.ts
+++ b/src/api/repositories/ListingItemRepository.ts
@@ -46,8 +46,8 @@ export class ListingItemRepository {
      * @param options, ListingItemSearchParams
      * @returns {Promise<Bookshelf.Collection<ListingItem>>}
      */
-    public async search(options: ListingItemSearchParams): Promise<Bookshelf.Collection<ListingItem>> {
-        return this.ListingItemModel.searchBy(options);
+    public async search(options: ListingItemSearchParams, withRelated: boolean): Promise<Bookshelf.Collection<ListingItem>> {
+        return this.ListingItemModel.searchBy(options, withRelated);
 
     }
 

--- a/src/api/requests/ListingItemSearchParams.ts
+++ b/src/api/requests/ListingItemSearchParams.ts
@@ -19,5 +19,7 @@ export class ListingItemSearchParams extends RequestBody {
 
     public searchString: string;
 
+    public withRelated: boolean;
+
 }
 

--- a/src/api/requests/ListingItemSearchParams.ts
+++ b/src/api/requests/ListingItemSearchParams.ts
@@ -19,7 +19,5 @@ export class ListingItemSearchParams extends RequestBody {
 
     public searchString: string;
 
-    public withRelated: boolean;
-
 }
 

--- a/src/api/services/ListingItemService.ts
+++ b/src/api/services/ListingItemService.ts
@@ -64,11 +64,11 @@ export class ListingItemService {
      * @returns {Promise<Bookshelf.Collection<ListingItem>>}
      */
     @validate()
-    public async search(@request(ListingItemSearchParams) options: any): Promise<Bookshelf.Collection<ListingItem>> {
+    public async search(@request(ListingItemSearchParams) options: ListingItemSearchParams, withRelated: boolean = false): Promise<Bookshelf.Collection<ListingItem>> {
 
         // if valid params
         // todo: check whether category is string or number, if string, try to find the Category by key
-        return this.listingItemRepo.search(options);
+        return this.listingItemRepo.search(options, withRelated);
     }
 
     @validate()

--- a/src/api/services/ListingItemService.ts
+++ b/src/api/services/ListingItemService.ts
@@ -71,18 +71,6 @@ export class ListingItemService {
         return this.listingItemRepo.search(options);
     }
 
-    /**
-     * TODO: remove this and add the category as a search param to search
-     */
-    public async searchByCategoryIdOrName(options: any): Promise<Bookshelf.Collection<ListingItem>> {
-        const listingItem = await this.listingItemRepo.searchByCategoryIdOrName(options);
-        if (listingItem === null) {
-            this.log.warn(`ListingItem with the category=${options[0]} was not found!`);
-            throw new NotFoundException(options[0]);
-        }
-        return listingItem;
-    }
-
     @validate()
     public async create(@request(ListingItemCreateRequest) body: any): Promise<ListingItem> {
 

--- a/src/api/services/rpc/RpcListingItemService.ts
+++ b/src/api/services/rpc/RpcListingItemService.ts
@@ -99,7 +99,8 @@ export class RpcListingItemService {
             pageLimit: data.params[1] || 5,
             order: data.params[2] || 'ASC',
             category: data.params[3],
-            searchString: data.params[4]
+            searchString: data.params[4] || '',
+            withRelated: data.params[5] || false
         } as ListingItemSearchParams);
     }
 

--- a/src/api/services/rpc/RpcListingItemService.ts
+++ b/src/api/services/rpc/RpcListingItemService.ts
@@ -99,9 +99,8 @@ export class RpcListingItemService {
             pageLimit: data.params[1] || 5,
             order: data.params[2] || 'ASC',
             category: data.params[3],
-            searchString: data.params[4] || '',
-            withRelated: data.params[5] || false
-        } as ListingItemSearchParams);
+            searchString: data.params[4] || ''
+        } as ListingItemSearchParams, data.params[5]);
     }
 
     /**

--- a/test/black-box/RpcFindItems.test.ts
+++ b/test/black-box/RpcFindItems.test.ts
@@ -1,0 +1,329 @@
+import { api } from './lib/api';
+import { DatabaseResetCommand } from '../../src/console/DatabaseResetCommand';
+import { Country } from '../../src/api/enums/Country';
+import { ShippingAvailability } from '../../src/api/enums/ShippingAvailability';
+import { ImageDataProtocolType } from '../../src/api/enums/ImageDataProtocolType';
+import { PaymentType } from '../../src/api/enums/PaymentType';
+import { EscrowType } from '../../src/api/enums/EscrowType';
+import { Currency } from '../../src/api/enums/Currency';
+import { CryptocurrencyAddressType } from '../../src/api/enums/CryptocurrencyAddressType';
+import { MessagingProtocolType } from '../../src/api/enums/MessagingProtocolType';
+
+describe('/listing-items', () => {
+
+    const keys = [
+        'id', 'hash', 'updatedAt', 'createdAt'  // , 'Related'
+    ];
+
+    const testData = {
+        hash: 'hash1',
+        itemInformation: {
+            title: 'item title1',
+            shortDescription: 'item short desc1',
+            longDescription: 'item long desc1',
+            itemCategory: {
+                name: 'ROOT',
+                description: 'item category description 1',
+                key: 'ROOT'
+            },
+            itemLocation: {
+                region: Country.SOUTH_AFRICA,
+                address: 'asdf, asdf, asdf',
+                locationMarker: {
+                    markerTitle: 'Helsinki',
+                    markerText: 'Helsinki',
+                    lat: 12.1234,
+                    lng: 23.2314
+                }
+            },
+            shippingDestinations: [{
+                country: Country.UNITED_KINGDOM,
+                shippingAvailability: ShippingAvailability.DOES_NOT_SHIP
+            }, {
+                country: Country.ASIA,
+                shippingAvailability: ShippingAvailability.SHIPS
+            }, {
+                country: Country.SOUTH_AFRICA,
+                shippingAvailability: ShippingAvailability.ASK
+            }],
+            itemImages: [{
+                hash: 'imagehash1',
+                data: {
+                    dataId: 'dataid1',
+                    protocol: ImageDataProtocolType.IPFS,
+                    encoding: null,
+                    data: null
+                }
+            }, {
+                hash: 'imagehash2',
+                data: {
+                    dataId: 'dataid2',
+                    protocol: ImageDataProtocolType.LOCAL,
+                    encoding: 'BASE64',
+                    data: 'BASE64 encoded image data'
+                }
+            }, {
+                hash: 'imagehash3',
+                data: {
+                    dataId: 'dataid3',
+                    protocol: ImageDataProtocolType.SMSG,
+                    encoding: null,
+                    data: 'smsgdata'
+                }
+            }]
+        },
+        paymentInformation: {
+            type: PaymentType.SALE,
+            escrow: {
+                type: EscrowType.MAD,
+                ratio: {
+                    buyer: 100,
+                    seller: 100
+                }
+            },
+            itemPrice: {
+                currency: Currency.BITCOIN,
+                basePrice: 0.0001,
+                shippingPrice: {
+                    domestic: 0.123,
+                    international: 1.234
+                },
+                address: {
+                    type: CryptocurrencyAddressType.NORMAL,
+                    address: '1234'
+                }
+            }
+        },
+        messagingInformation: {
+            protocol: MessagingProtocolType.SMSG,
+            publicKey: 'publickey1'
+        }
+    };
+
+    const testDataTwo = {
+        hash: 'hash2',
+        itemInformation: {
+            title: 'title UPDATED',
+            shortDescription: 'item UPDATED',
+            longDescription: 'item UPDATED',
+            itemCategory: {
+                name: 'CHILD',
+                description: 'item UPDATED',
+                key: 'CHILD'
+            },
+            itemLocation: {
+                region: Country.FINLAND,
+                address: 'asdf UPDATED',
+                locationMarker: {
+                    markerTitle: 'UPDATED',
+                    markerText: 'UPDATED',
+                    lat: 33.333,
+                    lng: 44.333
+                }
+            },
+            shippingDestinations: [{
+                country: Country.EU,
+                shippingAvailability: ShippingAvailability.SHIPS
+            }],
+            itemImages: [{
+                hash: 'imagehash1 UPDATED',
+                data: {
+                    dataId: 'dataid1 UPDATED',
+                    protocol: ImageDataProtocolType.IPFS,
+                    encoding: null,
+                    data: null
+                }
+            }]
+        },
+        paymentInformation: {
+            type: PaymentType.FREE,
+            escrow: {
+                type: EscrowType.MAD,
+                ratio: {
+                    buyer: 1,
+                    seller: 1
+                }
+            },
+            itemPrice: {
+                currency: Currency.PARTICL,
+                basePrice: 3.333,
+                shippingPrice: {
+                    domestic: 1.111,
+                    international: 2.222
+                },
+                address: {
+                    type: CryptocurrencyAddressType.STEALTH,
+                    address: '1234 UPDATED'
+                }
+            }
+        },
+        messagingInformation: {
+            protocol: MessagingProtocolType.SMSG,
+            publicKey: 'publickey1 UPDATED'
+        }
+    };
+
+    let createdId;
+    let createdHash;
+    let createdHashTwo;
+    let createdCategory;
+    let createdItemInformation;
+    beforeAll(async () => {
+        const command = new DatabaseResetCommand();
+        await command.run();
+    });
+
+
+    test('Should list listing items with our new create one', async () => {
+        const res = await api('POST', '/api/listing-items', {
+            body: testData
+        });
+        res.expectJson();
+        res.expectStatusCode(201);
+        res.expectData(keys);
+        createdId = res.getData()['id'];
+        createdHash = res.getData()['hash'];
+        createdItemInformation = res.getData()['ItemInformation'];
+        createdCategory = createdItemInformation.ItemCategory;
+
+        // create second listing item
+        const resTwo = await api('POST', '/api/listing-items', {
+            body: testDataTwo
+        });
+
+    });
+
+    test('Should get all listing items', async () => {
+        const resMain = await api('POST', `/api/rpc`, {
+            body: {
+                method: 'finditems',
+                params:  [1, 2, 'ASC'],
+                id: 1,
+                jsonrpc: '2.0'
+            }
+        });
+
+        resMain.expectJson();
+        resMain.expectStatusCode(200);
+        resMain.expectDataRpc(keys);
+        const resultMain: any = resMain.getBody()['result'];
+        createdHashTwo = resultMain[1].hash;
+        expect(resultMain.length).toBe(2);
+        expect(createdHash).toBe(resultMain[0].hash);
+        expect(createdHashTwo).toBe(resultMain[1].hash);
+    });
+
+    test('Should get only first listing item by pagination', async () => {
+        const resPageOne = await api('POST', `/api/rpc`, {
+            body: {
+                method: 'finditems',
+                params:  [1, 1, 'ASC'],
+                id: 1,
+                jsonrpc: '2.0'
+            }
+
+        });
+        resPageOne.expectJson();
+        resPageOne.expectStatusCode(200);
+        resPageOne.expectDataRpc(keys);
+        const resultPageOne: any = resPageOne.getBody()['result'];
+        expect(resultPageOne.length).toBe(1);
+        expect(createdHash).toBe(resultPageOne[0].hash);
+    });
+
+    test('Should get second listing item by pagination', async () => {
+        const resPageTwo = await api('POST', `/api/rpc`, {
+            body: {
+                method: 'finditems',
+                params:  [2, 1, 'ASC'],
+                id: 1,
+                jsonrpc: '2.0'
+            }
+
+        });
+        resPageTwo.expectJson();
+        resPageTwo.expectStatusCode(200);
+        resPageTwo.expectDataRpc(keys);
+        const resultPageTwo: any = resPageTwo.getBody()['result'];
+        expect(resultPageTwo.length).toBe(1);
+        expect(createdHashTwo).toBe(resultPageTwo[0].hash);
+    });
+
+    test('Should return empty listing items array if invalid pagination', async () => {
+        const resEmpty = await api('POST', `/api/rpc`, {
+            body: {
+                method: 'finditems',
+                params:  [2, 2, 'ASC'],
+                id: 1,
+                jsonrpc: '2.0'
+            }
+
+        });
+
+        resEmpty.expectJson();
+        resEmpty.expectStatusCode(200);
+        const emptyListingResults: any = resEmpty.getBody()['result'];
+        expect(emptyListingResults.length).toBe(0);
+    });
+
+    test('Should search listing items by category key', async () => {
+        const resByCategoryName = await api('POST', `/api/rpc`, {
+            body: {
+                method: 'finditems',
+                params:  [1, 2, 'ASC', createdCategory.key, '', true],
+                id: 1,
+                jsonrpc: '2.0'
+            }
+
+        });
+        resByCategoryName.expectJson();
+        resByCategoryName.expectStatusCode(200);
+        const listingCategoryResults: any = resByCategoryName.getBody()['result'];
+        const category = listingCategoryResults[0].ItemInformation.ItemCategory;
+        expect(listingCategoryResults.length).toBe(1);
+        expect(createdCategory.key).toBe(category.key);
+
+    });
+
+    test('Should search listing items by category id', async () => {
+        const resByCategoryId = await api('POST', `/api/rpc`, {
+            body: {
+                method: 'finditems',
+                params:  [1, 2, 'ASC', createdCategory.id, '', true],
+                id: 1,
+                jsonrpc: '2.0'
+            }
+
+        });
+        resByCategoryId.expectJson();
+        resByCategoryId.expectStatusCode(200);
+        const listingCategoryByIdResults: any = resByCategoryId.getBody()['result'];
+
+        const categoryById = listingCategoryByIdResults[0].ItemInformation.ItemCategory;
+        expect(listingCategoryByIdResults.length).toBe(1);
+        expect(createdCategory.id).toBe(categoryById.id);
+    });
+
+
+    test('Should search listing items by ItemInformation title', async () => {
+        const resByCategoryByTitle = await api('POST', `/api/rpc`, {
+            body: {
+                method: 'finditems',
+                params:  [1, 2, 'ASC', '', createdItemInformation.title, true],
+                id: 1,
+                jsonrpc: '2.0'
+            }
+
+        });
+        resByCategoryByTitle.expectJson();
+        resByCategoryByTitle.expectStatusCode(200);
+        const listingCategoryByTitleResults: any = resByCategoryByTitle.getBody()['result'];
+
+        const ItemInformation = listingCategoryByTitleResults[0].ItemInformation;
+        expect(listingCategoryByTitleResults.length).toBe(1);
+        expect(createdItemInformation.title).toBe(ItemInformation.title);
+    });
+});
+
+
+

--- a/test/black-box/RpcGetItem.test.ts
+++ b/test/black-box/RpcGetItem.test.ts
@@ -111,7 +111,9 @@ describe('/listing-items', () => {
         await command.run();
     });
 
-    test('POST      /listing-items        Should create a new listing item', async () => {
+
+    test('Should get the listing item by hash and id', async () => {
+        // create listing item
         const res = await api('POST', '/api/listing-items', {
             body: testData
         });
@@ -120,78 +122,94 @@ describe('/listing-items', () => {
         res.expectData(keys);
         createdId = res.getData()['id'];
         createdHash = res.getData()['hash'];
-        const result: any = res.getData();
-        expect(result.hash).toBe(testData.hash);
-        expect(result.ItemInformation.title).toBe(testData.itemInformation.title);
-        expect(result.ItemInformation.shortDescription).toBe(testData.itemInformation.shortDescription);
-        expect(result.ItemInformation.longDescription).toBe(testData.itemInformation.longDescription);
-        expect(result.ItemInformation.ItemCategory.name).toBe(testData.itemInformation.itemCategory.name);
-        expect(result.ItemInformation.ItemCategory.description).toBe(testData.itemInformation.itemCategory.description);
-        expect(result.ItemInformation.ItemLocation.region).toBe(testData.itemInformation.itemLocation.region);
-        expect(result.ItemInformation.ItemLocation.address).toBe(testData.itemInformation.itemLocation.address);
-        expect(result.ItemInformation.ItemLocation.LocationMarker.markerTitle).toBe(testData.itemInformation.itemLocation.locationMarker.markerTitle);
-        expect(result.ItemInformation.ItemLocation.LocationMarker.markerText).toBe(testData.itemInformation.itemLocation.locationMarker.markerText);
-        expect(result.ItemInformation.ItemLocation.LocationMarker.lat).toBe(testData.itemInformation.itemLocation.locationMarker.lat);
-        expect(result.ItemInformation.ItemLocation.LocationMarker.lng).toBe(testData.itemInformation.itemLocation.locationMarker.lng);
-        expect(result.ItemInformation.ShippingDestinations).toHaveLength(3);
-        expect(result.ItemInformation.ItemImages).toHaveLength(3);
-        expect(result.PaymentInformation.type).toBe(testData.paymentInformation.type);
-        expect(result.PaymentInformation.Escrow.type).toBe(testData.paymentInformation.escrow.type);
-        expect(result.PaymentInformation.Escrow.Ratio.buyer).toBe(testData.paymentInformation.escrow.ratio.buyer);
-        expect(result.PaymentInformation.Escrow.Ratio.seller).toBe(testData.paymentInformation.escrow.ratio.seller);
-        expect(result.PaymentInformation.ItemPrice.currency).toBe(testData.paymentInformation.itemPrice.currency);
-        expect(result.PaymentInformation.ItemPrice.basePrice).toBe(testData.paymentInformation.itemPrice.basePrice);
-        expect(result.PaymentInformation.ItemPrice.ShippingPrice.domestic).toBe(testData.paymentInformation.itemPrice.shippingPrice.domestic);
-        expect(result.PaymentInformation.ItemPrice.ShippingPrice.international).toBe(testData.paymentInformation.itemPrice.shippingPrice.international);
-        expect(result.PaymentInformation.ItemPrice.Address.type).toBe(testData.paymentInformation.itemPrice.address.type);
-        expect(result.PaymentInformation.ItemPrice.Address.address).toBe(testData.paymentInformation.itemPrice.address.address);
-        expect(result.MessagingInformation.protocol).toBe(testData.messagingInformation.protocol);
-        expect(result.MessagingInformation.publicKey).toBe(testData.messagingInformation.publicKey);
-    });
 
-    test('POST     /listing-items/hash/:hash    Should return one listing item', async () => {
-        const res = await api('POST', `/api/rpc`, {
+        // find listing item by hash
+        const resMain = await api('POST', `/api/rpc`, {
               body: {
-                  method: 'listingitem.getitembyhash',
+                  method: 'getitem',
                   params:  [createdHash],
                   id: 1,
                   jsonrpc: '2.0'
               }
 
         });
-        // res.expectJson();
-        // res.expectStatusCode(201);
-        // const result: any = res.getData();
-        const result = res.res.body;
 
-        expect(result.hash).toBe(testData.hash);
-        expect(createdHash).toBe(result.hash);
-        expect(result.ItemInformation.title).toBe(testData.itemInformation.title);
-        expect(result.ItemInformation.shortDescription).toBe(testData.itemInformation.shortDescription);
-        expect(result.ItemInformation.longDescription).toBe(testData.itemInformation.longDescription);
-        expect(result.ItemInformation.ItemCategory.name).toBe(testData.itemInformation.itemCategory.name);
-        expect(result.ItemInformation.ItemCategory.description).toBe(testData.itemInformation.itemCategory.description);
-        expect(result.ItemInformation.ItemLocation.region).toBe(testData.itemInformation.itemLocation.region);
-        expect(result.ItemInformation.ItemLocation.address).toBe(testData.itemInformation.itemLocation.address);
-        expect(result.ItemInformation.ItemLocation.LocationMarker.markerTitle).toBe(testData.itemInformation.itemLocation.locationMarker.markerTitle);
-        expect(result.ItemInformation.ItemLocation.LocationMarker.markerText).toBe(testData.itemInformation.itemLocation.locationMarker.markerText);
-        expect(result.ItemInformation.ItemLocation.LocationMarker.lat).toBe(testData.itemInformation.itemLocation.locationMarker.lat);
-        expect(result.ItemInformation.ItemLocation.LocationMarker.lng).toBe(testData.itemInformation.itemLocation.locationMarker.lng);
-        expect(result.ItemInformation.ShippingDestinations).toHaveLength(3);
-        expect(result.ItemInformation.ItemImages).toHaveLength(3);
-        expect(result.PaymentInformation.type).toBe(testData.paymentInformation.type);
-        expect(result.PaymentInformation.Escrow.type).toBe(testData.paymentInformation.escrow.type);
-        expect(result.PaymentInformation.Escrow.Ratio.buyer).toBe(testData.paymentInformation.escrow.ratio.buyer);
-        expect(result.PaymentInformation.Escrow.Ratio.seller).toBe(testData.paymentInformation.escrow.ratio.seller);
-        expect(result.PaymentInformation.ItemPrice.currency).toBe(testData.paymentInformation.itemPrice.currency);
-        expect(result.PaymentInformation.ItemPrice.basePrice).toBe(testData.paymentInformation.itemPrice.basePrice);
-        expect(result.PaymentInformation.ItemPrice.ShippingPrice.domestic).toBe(testData.paymentInformation.itemPrice.shippingPrice.domestic);
-        expect(result.PaymentInformation.ItemPrice.ShippingPrice.international).toBe(testData.paymentInformation.itemPrice.shippingPrice.international);
-        expect(result.PaymentInformation.ItemPrice.Address.type).toBe(testData.paymentInformation.itemPrice.address.type);
-        expect(result.PaymentInformation.ItemPrice.Address.address).toBe(testData.paymentInformation.itemPrice.address.address);
-        expect(result.MessagingInformation.protocol).toBe(testData.messagingInformation.protocol);
-        expect(result.MessagingInformation.publicKey).toBe(testData.messagingInformation.publicKey);
+        resMain.expectJson();
+        resMain.expectStatusCode(200);
+        resMain.expectDataRpc(keys);
+        const resultMain: any = resMain.getBody()['result'];
 
+        expect(resultMain.hash).toBe(testData.hash);
+        expect(createdHash).toBe(resultMain.hash);
+        expect(resultMain.ItemInformation.title).toBe(testData.itemInformation.title);
+        expect(resultMain.ItemInformation.shortDescription).toBe(testData.itemInformation.shortDescription);
+        expect(resultMain.ItemInformation.longDescription).toBe(testData.itemInformation.longDescription);
+        expect(resultMain.ItemInformation.ItemCategory.name).toBe(testData.itemInformation.itemCategory.name);
+        expect(resultMain.ItemInformation.ItemCategory.description).toBe(testData.itemInformation.itemCategory.description);
+        expect(resultMain.ItemInformation.ItemLocation.region).toBe(testData.itemInformation.itemLocation.region);
+        expect(resultMain.ItemInformation.ItemLocation.address).toBe(testData.itemInformation.itemLocation.address);
+        expect(resultMain.ItemInformation.ItemLocation.LocationMarker.markerTitle).toBe(testData.itemInformation.itemLocation.locationMarker.markerTitle);
+        expect(resultMain.ItemInformation.ItemLocation.LocationMarker.markerText).toBe(testData.itemInformation.itemLocation.locationMarker.markerText);
+        expect(resultMain.ItemInformation.ItemLocation.LocationMarker.lat).toBe(testData.itemInformation.itemLocation.locationMarker.lat);
+        expect(resultMain.ItemInformation.ItemLocation.LocationMarker.lng).toBe(testData.itemInformation.itemLocation.locationMarker.lng);
+        expect(resultMain.ItemInformation.ShippingDestinations).toHaveLength(3);
+        expect(resultMain.ItemInformation.ItemImages).toHaveLength(3);
+        expect(resultMain.PaymentInformation.type).toBe(testData.paymentInformation.type);
+        expect(resultMain.PaymentInformation.Escrow.type).toBe(testData.paymentInformation.escrow.type);
+        expect(resultMain.PaymentInformation.Escrow.Ratio.buyer).toBe(testData.paymentInformation.escrow.ratio.buyer);
+        expect(resultMain.PaymentInformation.Escrow.Ratio.seller).toBe(testData.paymentInformation.escrow.ratio.seller);
+        expect(resultMain.PaymentInformation.ItemPrice.currency).toBe(testData.paymentInformation.itemPrice.currency);
+        expect(resultMain.PaymentInformation.ItemPrice.basePrice).toBe(testData.paymentInformation.itemPrice.basePrice);
+        expect(resultMain.PaymentInformation.ItemPrice.ShippingPrice.domestic).toBe(testData.paymentInformation.itemPrice.shippingPrice.domestic);
+        expect(resultMain.PaymentInformation.ItemPrice.ShippingPrice.international).toBe(testData.paymentInformation.itemPrice.shippingPrice.international);
+        expect(resultMain.PaymentInformation.ItemPrice.Address.type).toBe(testData.paymentInformation.itemPrice.address.type);
+        expect(resultMain.PaymentInformation.ItemPrice.Address.address).toBe(testData.paymentInformation.itemPrice.address.address);
+        expect(resultMain.MessagingInformation.protocol).toBe(testData.messagingInformation.protocol);
+        expect(resultMain.MessagingInformation.publicKey).toBe(testData.messagingInformation.publicKey);
+
+
+        // find listing item by id
+        const resMainById = await api('POST', `/api/rpc`, {
+            body: {
+                method: 'getitem',
+                params:  [createdId],
+                id: 1,
+                jsonrpc: '2.0'
+            }
+        });
+
+        resMainById.expectJson();
+        resMainById.expectStatusCode(200);
+        resMainById.expectDataRpc(keys);
+        const resultMainById: any = resMainById.getBody()['result'];
+
+        expect(resultMainById.hash).toBe(testData.hash);
+        expect(createdHash).toBe(resultMainById.hash);
+        expect(resultMainById.ItemInformation.title).toBe(testData.itemInformation.title);
+        expect(resultMainById.ItemInformation.shortDescription).toBe(testData.itemInformation.shortDescription);
+        expect(resultMainById.ItemInformation.longDescription).toBe(testData.itemInformation.longDescription);
+        expect(resultMainById.ItemInformation.ItemCategory.name).toBe(testData.itemInformation.itemCategory.name);
+        expect(resultMainById.ItemInformation.ItemCategory.description).toBe(testData.itemInformation.itemCategory.description);
+        expect(resultMainById.ItemInformation.ItemLocation.region).toBe(testData.itemInformation.itemLocation.region);
+        expect(resultMainById.ItemInformation.ItemLocation.address).toBe(testData.itemInformation.itemLocation.address);
+        expect(resultMainById.ItemInformation.ItemLocation.LocationMarker.markerTitle).toBe(testData.itemInformation.itemLocation.locationMarker.markerTitle);
+        expect(resultMainById.ItemInformation.ItemLocation.LocationMarker.markerText).toBe(testData.itemInformation.itemLocation.locationMarker.markerText);
+        expect(resultMainById.ItemInformation.ItemLocation.LocationMarker.lat).toBe(testData.itemInformation.itemLocation.locationMarker.lat);
+        expect(resultMainById.ItemInformation.ItemLocation.LocationMarker.lng).toBe(testData.itemInformation.itemLocation.locationMarker.lng);
+        expect(resultMainById.ItemInformation.ShippingDestinations).toHaveLength(3);
+        expect(resultMainById.ItemInformation.ItemImages).toHaveLength(3);
+        expect(resultMainById.PaymentInformation.type).toBe(testData.paymentInformation.type);
+        expect(resultMainById.PaymentInformation.Escrow.type).toBe(testData.paymentInformation.escrow.type);
+        expect(resultMainById.PaymentInformation.Escrow.Ratio.buyer).toBe(testData.paymentInformation.escrow.ratio.buyer);
+        expect(resultMainById.PaymentInformation.Escrow.Ratio.seller).toBe(testData.paymentInformation.escrow.ratio.seller);
+        expect(resultMainById.PaymentInformation.ItemPrice.currency).toBe(testData.paymentInformation.itemPrice.currency);
+        expect(resultMainById.PaymentInformation.ItemPrice.basePrice).toBe(testData.paymentInformation.itemPrice.basePrice);
+        expect(resultMainById.PaymentInformation.ItemPrice.ShippingPrice.domestic).toBe(testData.paymentInformation.itemPrice.shippingPrice.domestic);
+        expect(resultMainById.PaymentInformation.ItemPrice.ShippingPrice.international).toBe(testData.paymentInformation.itemPrice.shippingPrice.international);
+        expect(resultMainById.PaymentInformation.ItemPrice.Address.type).toBe(testData.paymentInformation.itemPrice.address.type);
+        expect(resultMainById.PaymentInformation.ItemPrice.Address.address).toBe(testData.paymentInformation.itemPrice.address.address);
+        expect(resultMainById.MessagingInformation.protocol).toBe(testData.messagingInformation.protocol);
+        expect(resultMainById.MessagingInformation.publicKey).toBe(testData.messagingInformation.publicKey);
 
     });
 

--- a/test/black-box/RpcGetItem.test.ts
+++ b/test/black-box/RpcGetItem.test.ts
@@ -112,7 +112,7 @@ describe('/listing-items', () => {
     });
 
 
-    test('Should get the listing item by hash and id', async () => {
+    test('Should get the listing item by hash', async () => {
         // create listing item
         const res = await api('POST', '/api/listing-items', {
             body: testData
@@ -120,17 +120,16 @@ describe('/listing-items', () => {
         res.expectJson();
         res.expectStatusCode(201);
         res.expectData(keys);
-        createdId = res.getData()['id'];
         createdHash = res.getData()['hash'];
-
+        createdId = res.getData()['id'];
         // find listing item by hash
         const resMain = await api('POST', `/api/rpc`, {
-              body: {
-                  method: 'getitem',
-                  params:  [createdHash],
-                  id: 1,
-                  jsonrpc: '2.0'
-              }
+            body: {
+                method: 'getitem',
+                params:  [createdHash],
+                id: 1,
+                jsonrpc: '2.0'
+            }
 
         });
 
@@ -166,8 +165,9 @@ describe('/listing-items', () => {
         expect(resultMain.PaymentInformation.ItemPrice.Address.address).toBe(testData.paymentInformation.itemPrice.address.address);
         expect(resultMain.MessagingInformation.protocol).toBe(testData.messagingInformation.protocol);
         expect(resultMain.MessagingInformation.publicKey).toBe(testData.messagingInformation.publicKey);
+    });
 
-
+    test('Should get the listing item by id', async () => {
         // find listing item by id
         const resMainById = await api('POST', `/api/rpc`, {
             body: {

--- a/test/black-box/lib/ApiResponseTest.ts
+++ b/test/black-box/lib/ApiResponseTest.ts
@@ -50,7 +50,7 @@ export class ApiResponseTest {
     }
 
     public expectDataRpc(keys: string[]): ApiResponseTest {
-        const result: object = this.getBody()['result'];
+        const result: object = _.isArray(this.getBody()['result']) ? this.getBody()['result'][0] : this.getBody()['result'];
         expect(_.every(keys, _.partial(_.has, result))).toBe(true);
         return this;
     }


### PR DESCRIPTION
- todo for PR#2:
  - search method:
    - combine rpcSearchByCategoryIdOrName and getItems functionality in search
      method (search using category)
    - use ListingItemSearchParams interface (~done)
    - add category as one possible search parameter (~done)
    - if category was given as key, find it's id
    - add withRelated as a param to search method, default value = false
  - add tests for profile and addresses that test the real rpc api
    create separate test files for each rpc-method
    - RpcFindItems.test.ts
    - RpcGetItem.test.ts
  - add a test to make sure listingItemService.findOne works with both id and name